### PR TITLE
Add support for Glitter library

### DIFF
--- a/Source/SharpNeedle/Glitter/AnimationParameter.cs
+++ b/Source/SharpNeedle/Glitter/AnimationParameter.cs
@@ -1,0 +1,37 @@
+﻿namespace SharpNeedle.Glitter;
+
+public class AnimationParameter : IBinarySerializable
+{
+    public List<Keyframe> Keyframes { get; set; } = new();
+    public int Field08 { get; set; }
+    public int Field0C { get; set; }
+
+    public void Read(BinaryObjectReader reader)
+    {
+        long keyframeOffset = reader.ReadOffsetValue();
+        int keyframeCount = reader.Read<int>();
+
+        reader.ReadAtOffset(keyframeOffset, () =>
+        {
+            for (int i = 0; i < keyframeCount; i++)
+                Keyframes.Add(reader.ReadObject<Keyframe>());
+        });
+
+        Field08 = reader.Read<int>();
+        Field0C = reader.Read<int>();
+    }
+
+    public void Write(BinaryObjectWriter writer)
+    {
+        writer.WriteOffset(() =>
+        {
+            foreach (var keyframe in Keyframes)
+                writer.WriteObject(keyframe);
+        });
+
+        writer.Write(Keyframes.Count);
+
+        writer.Write(Field08);
+        writer.Write(Field0C);
+    }
+}

--- a/Source/SharpNeedle/Glitter/Effect.cs
+++ b/Source/SharpNeedle/Glitter/Effect.cs
@@ -14,6 +14,10 @@ public class Effect : BinaryResource
         reader.EnsureSignature(Signature);
 
         Version = reader.Read<uint>();
+        if (Version != 0x01060000)
+        {
+            throw new NotSupportedException();
+        }
 
         reader.Skip(4); // Always 0?
 
@@ -25,6 +29,11 @@ public class Effect : BinaryResource
 
     public override void Write(BinaryObjectWriter writer)
     {
+        if (Version != 0x01060000)
+        {
+            throw new NotSupportedException();
+        }
+
         writer.Write(Signature);
         writer.Write(Version);
 

--- a/Source/SharpNeedle/Glitter/Effect.cs
+++ b/Source/SharpNeedle/Glitter/Effect.cs
@@ -1,0 +1,35 @@
+﻿using SharpNeedle.BINA;
+
+namespace SharpNeedle.Glitter;
+
+[NeedleResource("glitter/effect", @"\.(gle|effect)$")]
+public class Effect : BinaryResource
+{
+    public new static readonly uint Signature = BinaryHelper.MakeSignature<uint>("FIRG");
+    public uint Version { get; set; }
+    public LinkedList<EffectParameter> Parameters { get; set; } = new();
+    
+    public override void Read(BinaryObjectReader reader)
+    {
+        reader.EnsureSignature(Signature);
+
+        Version = reader.Read<uint>();
+
+        reader.Skip(4); // Always 0?
+
+        reader.ReadOffset(() =>
+        {
+            Parameters.AddFirst(reader.ReadObject<EffectParameter, Effect>(this));
+        });
+    }
+
+    public override void Write(BinaryObjectWriter writer)
+    {
+        writer.Write(Signature);
+        writer.Write(Version);
+
+        writer.Write(0); // Always 0?
+
+        writer.WriteObjectOffset(Parameters.First.Value, this, 16);
+    }
+}

--- a/Source/SharpNeedle/Glitter/Effect.cs
+++ b/Source/SharpNeedle/Glitter/Effect.cs
@@ -1,12 +1,12 @@
-﻿using SharpNeedle.BINA;
+﻿namespace SharpNeedle.Glitter;
 
-namespace SharpNeedle.Glitter;
+using SharpNeedle.BINA;
 
 [NeedleResource("glitter/effect", @"\.(gle|effect)$")]
 public class Effect : BinaryResource
 {
     public new static readonly uint Signature = BinaryHelper.MakeSignature<uint>("FIRG");
-    public uint Version { get; set; }
+    public uint Version { get; set; } = 0x01060000;
     public LinkedList<EffectParameter> Parameters { get; set; } = new();
     
     public override void Read(BinaryObjectReader reader)

--- a/Source/SharpNeedle/Glitter/EffectParameter.cs
+++ b/Source/SharpNeedle/Glitter/EffectParameter.cs
@@ -1,0 +1,122 @@
+﻿using System.Diagnostics;
+using System.Reflection.PortableExecutable;
+
+namespace SharpNeedle.Glitter;
+
+public class EffectParameter : IBinarySerializable<Effect>
+{
+    public string Name { get; set; }
+    public float StartTime { get; set; }
+    public float LifeTime { get; set; }
+    public int PreprocessFrame { get; set; } // Guessed
+    public float EffectScale { get; set; } // Guessed
+    public float EmittingScale { get; set; } // Guessed
+    public float Opacity { get; set; } // Guessed
+    public float Field1C { get; set; }
+    public int Field50 { get; set; }
+    public int Field54 { get; set; }
+    public int Field58 { get; set; }
+    public int Field5C { get; set; }
+    public int Field60 { get; set; }
+    public bool Loop { get; set; }
+    public Vector3 Position { get; set; }
+    public Vector3 Rotation { get; set; }
+    public Vector3 Scale { get; set; }
+    public List<AnimationParameter> Animations { get; set; } = new(14);
+    public LinkedList<EmitterParameter> Emitters { get; set; } = new();
+
+    public void Read(BinaryObjectReader reader, Effect parent)
+    {
+        Name = reader.ReadStringOffset();
+
+        StartTime = reader.Read<float>();
+        LifeTime = reader.Read<float>();
+
+        PreprocessFrame = reader.Read<int>();
+
+        EffectScale = reader.Read<float>();
+        EmittingScale = reader.Read<float>();
+        Opacity = reader.Read<float>();
+
+        Field1C = reader.Read<float>();
+
+        reader.Align(16);
+        Position = reader.Read<Vector3>();
+        reader.Align(16);
+        Rotation = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        Scale = reader.Read<Vector3>();
+        reader.Align(16);
+
+        Field50 = reader.Read<int>();
+        Field54 = reader.Read<int>();
+        Field58 = reader.Read<int>();
+        Field5C = reader.Read<int>();
+        Field60 = reader.Read<int>();
+
+        Loop = Convert.ToBoolean(reader.Read<int>());
+
+        for (int i = 0; i < Animations.Capacity; i++)
+        {
+            Animations.Add(new());
+
+            long animationOffset = reader.ReadOffsetValue();
+            if (animationOffset != 0)
+                Animations[i] = reader.ReadObjectAtOffset<AnimationParameter>(animationOffset);
+        }
+
+        long emitterOffset = reader.ReadOffsetValue();
+        if (emitterOffset != 0)
+            Emitters.AddFirst(reader.ReadObjectAtOffset<EmitterParameter, EffectParameter>(emitterOffset, this));
+
+        long nextOffset = reader.ReadOffsetValue();
+        if (nextOffset != 0)
+            parent.Parameters.AddLast(reader.ReadObjectAtOffset<EffectParameter>(nextOffset));
+    }
+
+    public void Write(BinaryObjectWriter writer, Effect parent)
+    {
+        writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+        writer.Write(StartTime);
+        writer.Write(LifeTime);
+
+        writer.Write(PreprocessFrame);
+
+        writer.Write(EffectScale);
+        writer.Write(EmittingScale);
+        writer.Write(Opacity);
+        writer.Write(Field1C);
+
+        writer.Align(16);
+        writer.Write(Position);
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(Rotation));
+        writer.Align(16);
+        writer.Write(Scale);
+        writer.Align(16);
+
+        writer.Write(Field50);
+        writer.Write(Field54);
+        writer.Write(Field58);
+        writer.Write(Field5C);
+        writer.Write(Field60);
+
+        writer.Write(Convert.ToInt32(Loop));
+
+        foreach (var animation in Animations)
+        {
+            if (animation.Keyframes.Count != 0)
+                writer.WriteObjectOffset(animation);
+            else
+                writer.WriteOffsetValue(0);
+        }
+
+        writer.WriteObjectOffset(Emitters.First.Value, this, 16);
+
+        if (parent.Parameters.Find(this).Next != null)
+            writer.WriteObjectOffset(parent.Parameters.Find(this).Next.Value, parent, 16);
+        else
+            writer.WriteOffsetValue(0);
+    }
+}

--- a/Source/SharpNeedle/Glitter/EffectParameter.cs
+++ b/Source/SharpNeedle/Glitter/EffectParameter.cs
@@ -1,7 +1,4 @@
-﻿using System.Diagnostics;
-using System.Reflection.PortableExecutable;
-
-namespace SharpNeedle.Glitter;
+﻿namespace SharpNeedle.Glitter;
 
 public class EffectParameter : IBinarySerializable<Effect>
 {

--- a/Source/SharpNeedle/Glitter/EmitterParameter.cs
+++ b/Source/SharpNeedle/Glitter/EmitterParameter.cs
@@ -1,7 +1,6 @@
-﻿using SharpNeedle.SurfRide.Draw.Animations;
-using static SharpNeedle.Glitter.EmitterParameter.IShapeParameter;
+﻿namespace SharpNeedle.Glitter;
 
-namespace SharpNeedle.Glitter;
+using static SharpNeedle.Glitter.EmitterParameter.IShapeParameter;
 
 public class EmitterParameter : IBinarySerializable<EffectParameter>
 {

--- a/Source/SharpNeedle/Glitter/EmitterParameter.cs
+++ b/Source/SharpNeedle/Glitter/EmitterParameter.cs
@@ -1,0 +1,241 @@
+﻿using SharpNeedle.SurfRide.Draw.Animations;
+using static SharpNeedle.Glitter.EmitterParameter.IShapeParameter;
+
+namespace SharpNeedle.Glitter;
+
+public class EmitterParameter : IBinarySerializable<EffectParameter>
+{
+    public string Name { get; set; }
+    public EEmitterType EmitterType { get; set; }
+    public EEmitCondition EmitCondition { get; set; }
+    public EDirectionType DirectionType { get; set; }
+    public float StartTime { get; set; }
+    public float LifeTime { get; set; }
+    public float LoopStartPosition { get; set; }
+    public float LoopEndPosition { get; set; }
+    public float EmissionInterval { get; set; }
+    public float ParticlePerEmission { get; set; }
+    public int Field78 { get; set; }
+    public int Field7C { get; set; }
+    public int Field94 { get; set; }
+    public int Field98 { get; set; }
+    public int Field9C { get; set; }
+    public int Field100 { get; set; }
+    public int Field104 { get; set; }
+    public Vector3 InitialPosition { get; set; }
+    public Vector3 InitialRotation { get; set; }
+    public Vector3 Rotation { get; set; }
+    public Vector3 RotationRandomMargin { get; set; }
+    public Vector3 InitialScale { get; set; }
+    public ShapeParameterUnion ShapeParameter { get; set; }
+    public List<AnimationParameter> Animations { get; set; } = new(12);
+    public LinkedList<ParticleParameter> Particles { get; set; } = new();
+
+    public void Read(BinaryObjectReader reader, EffectParameter parent)
+    {
+        Name = reader.ReadStringOffset();
+
+        EmitterType = reader.Read<EEmitterType>();
+
+        StartTime = reader.Read<float>();
+        LifeTime = reader.Read<float>();
+
+        reader.Align(16);
+        InitialPosition = reader.Read<Vector3>();
+        reader.Align(16);
+        InitialRotation = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        Rotation = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        RotationRandomMargin = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        InitialScale = reader.Read<Vector3>();
+        reader.Align(16);
+
+        LoopStartPosition = reader.Read<float>();
+        LoopEndPosition = reader.Read<float>();
+
+        EmitCondition = reader.Read<EEmitCondition>();
+        DirectionType = reader.Read<EDirectionType>();
+
+        EmissionInterval = reader.Read<float>();
+        ParticlePerEmission = reader.Read<float>();
+
+        Field78 = reader.Read<int>();
+        Field7C = reader.Read<int>();
+
+        ShapeParameter = reader.Read<ShapeParameterUnion>();
+
+        Field94 = reader.Read<int>();
+        Field98 = reader.Read<int>();
+        Field9C = reader.Read<int>();
+        Field100 = reader.Read<int>();
+        Field104 = reader.Read<int>();
+
+        for (int i = 0; i < Animations.Capacity; i++)
+        {
+            Animations.Add(new());
+
+            long animationOffset = reader.ReadOffsetValue();
+            if (animationOffset != 0)
+                Animations[i] = reader.ReadObjectAtOffset<AnimationParameter>(animationOffset);
+        }
+
+        long particleOffset = reader.ReadOffsetValue();
+        if (particleOffset != 0)
+            Particles.AddFirst(reader.ReadObjectAtOffset<ParticleParameter, EmitterParameter>(particleOffset, this));
+
+        long nextOffset = reader.ReadOffsetValue();
+        if (nextOffset != 0)
+            parent.Emitters.AddLast(reader.ReadObjectAtOffset<EmitterParameter>(nextOffset));
+    }
+
+    public void Write(BinaryObjectWriter writer, EffectParameter parent)
+    {
+        writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+        writer.Write(EmitterType);
+
+        writer.Write(StartTime);
+        writer.Write(LifeTime);
+
+        writer.Align(16);
+        writer.Write(InitialPosition);
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(InitialRotation));
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(Rotation));
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(RotationRandomMargin));
+        writer.Align(16);
+        writer.Write(InitialScale);
+        writer.Align(16);
+
+        writer.Write(LoopStartPosition);
+        writer.Write(LoopEndPosition);
+        
+        writer.Write(EmitCondition);
+        writer.Write(DirectionType);
+
+        writer.Write(EmissionInterval);
+        writer.Write(ParticlePerEmission);
+
+        writer.Write(Field78);
+        writer.Write(Field7C);
+
+        writer.Write(ShapeParameter);
+
+        writer.Write(Field94);
+        writer.Write(Field98);
+        writer.Write(Field9C);
+        writer.Write(Field100);
+        writer.Write(Field104);
+
+        foreach (var animation in Animations)
+        {
+            if (animation.Keyframes.Count != 0)
+                writer.WriteObjectOffset(animation);
+            else
+                writer.WriteOffsetValue(0);
+        }
+
+        writer.WriteObjectOffset(Particles.First.Value, this, 16);
+
+        if (parent.Emitters.Find(this).Next != null)
+            writer.WriteObjectOffset(parent.Emitters.Find(this).Next.Value, parent, 16);
+        else
+            writer.WriteOffsetValue(0);
+    }
+
+    public enum EEmitterType : int
+    {
+        Cylinder = 1,
+        Sphere
+    };
+
+    public enum EEmitCondition : int
+    {
+        Time
+    };
+
+    public enum EDirectionType : int
+    {
+        ParentAxis
+    }
+
+    public interface IShapeParameter
+    {
+        public enum EEmissionDirectionType : int
+        {
+            Outward = 1
+        }
+    }
+
+    public struct BoxParameter : IShapeParameter
+    {
+        public Vector3 Size { get; set; }
+    }
+
+    public struct SphereParameter : IShapeParameter
+    {
+        public float Radius { get; set; }
+        public float Latitude { get; set; }
+        public float Longitude { get; set; }
+        public EEmissionDirectionType EmissionDirectionType { get; set; }
+    }
+
+    public struct CylinderParameter : IShapeParameter
+    {
+        public float Radius { get; set; }
+        public float Height { get; set; }
+        public float StartAngle { get; set; }
+        public float EndAngle { get; set; }
+        public EEmissionDirectionType EmissionDirectionType { get; set; }
+    }
+
+    public struct MeshParameter : IShapeParameter
+    {
+
+    }
+    
+    public struct PolygonParameter : IShapeParameter
+    {
+        public float Radius { get; set; }
+        public int PointCount { get; set; }
+        public EEmissionDirectionType EmissionDirectionType { get; set; }
+    }
+
+    [StructLayout(LayoutKind.Explicit, Size = 20)]
+    public struct ShapeParameterUnion
+    {
+        [FieldOffset(0)] public BoxParameter Box;
+        [FieldOffset(0)] public SphereParameter Sphere;
+        [FieldOffset(0)] public CylinderParameter Cylinder;
+        [FieldOffset(0)] public MeshParameter Mesh;
+        [FieldOffset(0)] public PolygonParameter Polygon;
+
+        public ShapeParameterUnion(BoxParameter value) : this() => Box = value;
+        public ShapeParameterUnion(SphereParameter value) : this() => Sphere = value;
+        public ShapeParameterUnion(CylinderParameter value) : this() => Cylinder = value;
+        public ShapeParameterUnion(MeshParameter value) : this() => Mesh = value;
+        public ShapeParameterUnion(PolygonParameter value) : this() => Polygon = value;
+
+        public void Set(BoxParameter value) => Box = value;
+        public void Set(SphereParameter value) => Sphere = value;
+        public void Set(CylinderParameter value) => Cylinder = value;
+        public void Set(MeshParameter value) => Mesh = value;
+        public void Set(PolygonParameter value) => Polygon = value;
+
+        public static implicit operator ShapeParameterUnion(BoxParameter value) => new(value);
+        public static implicit operator ShapeParameterUnion(SphereParameter value) => new(value);
+        public static implicit operator ShapeParameterUnion(CylinderParameter value) => new(value);
+        public static implicit operator ShapeParameterUnion(MeshParameter value) => new(value);
+        public static implicit operator ShapeParameterUnion(PolygonParameter value) => new(value);
+
+        public static implicit operator BoxParameter(ShapeParameterUnion value) => value.Box;
+        public static implicit operator SphereParameter(ShapeParameterUnion value) => value.Sphere;
+        public static implicit operator CylinderParameter(ShapeParameterUnion value) => value.Cylinder;
+        public static implicit operator MeshParameter(ShapeParameterUnion value) => value.Mesh;
+        public static implicit operator PolygonParameter(ShapeParameterUnion value) => value.Polygon;
+    }
+}

--- a/Source/SharpNeedle/Glitter/Keyframe.cs
+++ b/Source/SharpNeedle/Glitter/Keyframe.cs
@@ -1,6 +1,4 @@
-﻿using SharpNeedle.Ninja.Csd.Motions;
-
-namespace SharpNeedle.Glitter;
+﻿namespace SharpNeedle.Glitter;
 
 public class Keyframe : IBinarySerializable
 {

--- a/Source/SharpNeedle/Glitter/Keyframe.cs
+++ b/Source/SharpNeedle/Glitter/Keyframe.cs
@@ -1,0 +1,45 @@
+﻿using SharpNeedle.Ninja.Csd.Motions;
+
+namespace SharpNeedle.Glitter;
+
+public class Keyframe : IBinarySerializable
+{
+    public enum EInterpolationType : int
+    {
+        Linear = 1,
+        Hermite
+    };
+
+    public int Frame { get; set; }
+    public float Value { get; set; }
+    public float In { get; set; }
+    public float Out { get; set; }
+    public float Random { get; set; }
+    public EInterpolationType InterpolationType { get; set; }
+
+    public void Read(BinaryObjectReader reader)
+    {
+        Frame = reader.Read<int>();
+        Value = reader.Read<float>();
+
+        InterpolationType = reader.Read<EInterpolationType>();
+
+        In = reader.Read<float>();
+        Out = reader.Read<float>();
+
+        Random = reader.Read<float>();
+    }
+
+    public void Write(BinaryObjectWriter writer)
+    {
+        writer.Write(Frame);
+        writer.Write(Value);
+
+        writer.Write(InterpolationType);
+
+        writer.Write(In);
+        writer.Write(Out);
+
+        writer.Write(Random);
+    }
+}

--- a/Source/SharpNeedle/Glitter/MaterialParameter.cs
+++ b/Source/SharpNeedle/Glitter/MaterialParameter.cs
@@ -1,0 +1,102 @@
+﻿using System.Reflection.PortableExecutable;
+
+namespace SharpNeedle.Glitter;
+
+public class MaterialParameter : IBinarySerializable
+{
+    public string Name { get; set; }
+    public string ShaderName { get; set; }
+    public int TextureAddresMode { get; set; }
+    public int Field2C { get; set; }
+    public float Field30 { get; set; }
+    public int Field34 { get; set; }
+    public int Field38 { get; set; }
+    public float Field48 { get; set; }
+    public int Field4C { get; set; }
+    public int Field50 { get; set; }
+    public int Field54 { get; set; }
+    public int Field58 { get; set; }
+    public List<TextureData> TextureDatas { get; set; } = new(2);
+
+    public void Read(BinaryObjectReader reader)
+    {
+        Name = reader.ReadStringOffset();
+
+        for (int i = 0; i < 2; i++)
+            TextureDatas.Insert(i, reader.ReadObject<TextureData>());
+
+        int textureCount = reader.Read<int>();
+        TextureAddresMode = reader.Read<int>();
+
+        Field2C = reader.Read<int>();
+        Field30 = reader.Read<float>();
+        Field34 = reader.Read<int>();
+        Field38 = reader.Read<int>();
+
+        ShaderName = reader.ReadStringOffset();
+
+        reader.Skip(reader.GetOffsetSize()); // VertexShaderDataOffset
+        reader.Skip(reader.GetOffsetSize()); // PixelShaderDataOffset
+
+        Field48 = reader.Read<float>();
+        Field4C = reader.Read<int>();
+        Field50 = reader.Read<int>();
+        Field54 = reader.Read<int>();
+        Field58 = reader.Read<int>();
+    }
+
+    public void Write(BinaryObjectWriter writer)
+    {
+        writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+        for (int i = 0; i < TextureDatas.Capacity; i++)
+            writer.WriteObject(TextureDatas[i]);
+
+        writer.Write(TextureDatas.Capacity);
+        writer.Write(TextureAddresMode);
+
+        writer.Write(Field2C);
+        writer.Write(Field30);
+        writer.Write(Field34);
+        writer.Write(Field38);
+
+        writer.WriteStringOffset(StringBinaryFormat.NullTerminated, ShaderName);
+
+        writer.Skip(writer.GetOffsetSize()); // VertexShaderDataOffset
+        writer.Skip(writer.GetOffsetSize()); // PixelShaderDataOffset
+
+        writer.Write(Field48);
+        writer.Write(Field4C);
+        writer.Write(Field50);
+        writer.Write(Field54);
+        writer.Write(Field58);
+    }
+
+    public struct TextureData : IBinarySerializable
+    {
+        public string Name { get; set; }
+        public float Field04 { get; set; }
+        public int Field08 { get; set; }
+        public int Field0C { get; set; }
+
+        public void Read(BinaryObjectReader reader)
+        {
+            Name = reader.ReadStringOffset();
+
+            Field04 = reader.Read<float>();
+
+            Field08 = reader.Read<int>();
+            Field0C = reader.Read<int>();
+        }
+
+        public void Write(BinaryObjectWriter writer)
+        {
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+            writer.Write(Field04);
+
+            writer.Write(Field08);
+            writer.Write(Field0C);
+        }
+    }
+}

--- a/Source/SharpNeedle/Glitter/MaterialParameter.cs
+++ b/Source/SharpNeedle/Glitter/MaterialParameter.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection.PortableExecutable;
-
-namespace SharpNeedle.Glitter;
+﻿namespace SharpNeedle.Glitter;
 
 public class MaterialParameter : IBinarySerializable
 {

--- a/Source/SharpNeedle/Glitter/ParticleParameter.cs
+++ b/Source/SharpNeedle/Glitter/ParticleParameter.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection.PortableExecutable;
-
-namespace SharpNeedle.Glitter;
+﻿namespace SharpNeedle.Glitter;
 
 public class ParticleParameter : IBinarySerializable<EmitterParameter>
 {

--- a/Source/SharpNeedle/Glitter/ParticleParameter.cs
+++ b/Source/SharpNeedle/Glitter/ParticleParameter.cs
@@ -1,0 +1,436 @@
+﻿using System.Reflection.PortableExecutable;
+
+namespace SharpNeedle.Glitter;
+
+public class ParticleParameter : IBinarySerializable<EmitterParameter>
+{
+    public string Name { get; set; }
+    public EParticleType ParticleType { get; set; }
+    public EDirectionType DirectionType { get; set; }
+    public float LifeTime { get; set; }
+    public int ZOffset { get; set; }
+    public float InitialSpeed { get; set; }
+    public float InitialSpeedRandomMargin { get; set; }
+    public float Deceleration { get; set; }
+    public float DecelerationRandomMargin { get; set; }
+    public float FollowEmitterTranslationRatio { get; set; }
+    public float FollowEmitterTranslationYRatio { get; set; } // Guessed
+    public float EmitterTranslationEffectRatio { get; set; }
+    public float LocusInterval { get; set; } // Guessed
+    public ETextureIndexType TextureIndexType { get; set; }
+    public int TextureIndex { get; set; }
+    public int TextureIndexRangeStart { get; set; }
+    public int TextureIndexRangeEnd { get; set; }
+    public EBlendMode BlendMode { get; set; }
+    public ECompositeMode CompositeMode { get; set; }
+    public ESecondaryBlendMode SecondaryBlendMode { get; set; }
+    public int SecondaryBlend { get; set; }
+    public ETextureAddressMode TextureAddressMode { get; set; }
+    public int Flags { get; set; }
+    public float Field14 { get; set; }
+    public int Field118 { get; set; }
+    public int Field11C { get; set; }
+    public int Field120 { get; set; }
+    public int Field124 { get; set; }
+    public int Field128 { get; set; }
+    public int Field12C { get; set; }
+    public int Field130 { get; set; }
+    public int Field134 { get; set; }
+    public int Field138 { get; set; }
+    public int Field13C { get; set; }
+    public int Field150 { get; set; }
+    public int Field154 { get; set; }
+    public int Field158 { get; set; }
+    public int Field15C { get; set; }
+    public int Field160 { get; set; }
+    public float Field164 { get; set; }
+    public int Field168 { get; set; }
+    public int Field16C { get; set; }
+    public int Field170 { get; set; }
+    public int Field174 { get; set; }
+    public int Field178 { get; set; }
+    public int Field17C { get; set; }
+    public int Field180 { get; set; }
+    public int Field184 { get; set; }
+    public int Field188 { get; set; }
+    public int Field18C { get; set; }
+    public int Field190 { get; set; }
+    public int Field194 { get; set; }
+    public int Field198 { get; set; }
+    public int Field19C { get; set; }
+    public int Field1A0 { get; set; }
+    public int Field1BC { get; set; }
+    public int Field1C0 { get; set; }
+    public int Field1C4 { get; set; }
+    public int Field1C8 { get; set; }
+    public float Field1CC { get; set; }
+    public float Field1D0 { get; set; }
+    public int Field1D4 { get; set; }
+    public float Field1D8 { get; set; }
+    public int Field1DC { get; set; }
+    public int Field1E0 { get; set; }
+    public int Field1E4 { get; set; }
+    public int Field1E8 { get; set; }
+    public int Field1EC { get; set; }
+    public Color<float> BaseColor { get; set; }
+    public Color<float> MultiPurposeColor { get; set; }
+    public Vector3 InitialSize { get; set; }
+    public Vector3 InitialSizeRandomMargin { get; set; }
+    public Vector3 InitialRotation { get; set; }
+    public Vector3 InitialRotationRandomMargin { get; set; }
+    public Vector3 Rotation { get; set; }
+    public Vector3 RotationRandomMargin { get; set; }
+    public Vector3 InitialDirection { get; set; }
+    public Vector3 InitialDirectionRandomMargin { get; set; }
+    public Vector3 GravitionalAcceleration { get; set; }
+    public Vector3 ExternalAcceleration { get; set; }
+    public Vector3 ExternalAccelerationRandomMargin { get; set; }
+    public MaterialParameter Material { get; set; }
+    public MeshParameter Mesh { get; set; }
+    public List<Color<float>> ColorTables { get; set; } = new();
+    public List<Color<float>> ColorTable2s { get; set; } = new();
+    public List<AnimationParameter> Animations { get;set; } = new(30);
+
+    public void Read(BinaryObjectReader reader, EmitterParameter parent)
+    {
+        Name = reader.ReadStringOffset();
+
+        ParticleType = reader.Read<EParticleType>();
+
+        LifeTime = reader.Read<float>();
+
+        ZOffset = reader.Read<int>();
+
+        DirectionType = reader.Read<EDirectionType>();
+
+        Field14 = reader.Read<float>();
+
+        InitialSpeed = reader.Read<float>();
+        InitialSpeedRandomMargin = reader.Read<float>();
+        Deceleration = reader.Read<float>();
+        DecelerationRandomMargin = reader.Read<float>();
+        FollowEmitterTranslationRatio = reader.Read<float>();
+        FollowEmitterTranslationYRatio = reader.Read<float>();
+
+        BaseColor = reader.Read<Vector4>().AsColor();
+        MultiPurposeColor = reader.Read<Vector4>().AsColor();
+
+        long colorTableOffset = reader.ReadOffsetValue();
+        if (colorTableOffset != 0)
+            ColorTables.AddRange(reader.ReadArrayAtOffset<Color<float>>(colorTableOffset, reader.Read<int>()));
+
+        long colorTable2Offset = reader.ReadOffsetValue();
+        if (colorTable2Offset != 0)
+            ColorTable2s.AddRange(reader.ReadArrayAtOffset<Color<float>>(colorTable2Offset, reader.Read<int>()));
+
+        reader.Align(16);
+        InitialSize = reader.Read<Vector3>();
+        reader.Align(16);
+        InitialSizeRandomMargin = reader.Read<Vector3>();
+        reader.Align(16);
+        InitialRotation = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        InitialRotationRandomMargin = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        Rotation = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        RotationRandomMargin = MathHelper.ToDegrees(reader.Read<Vector3>());
+        reader.Align(16);
+        InitialDirection = reader.Read<Vector3>();
+        reader.Align(16);
+        InitialDirectionRandomMargin = reader.Read<Vector3>();
+        reader.Align(16);
+        GravitionalAcceleration = reader.Read<Vector3>();
+        reader.Align(16);
+        ExternalAcceleration = reader.Read<Vector3>();
+        reader.Align(16);
+        ExternalAccelerationRandomMargin = reader.Read<Vector3>();
+        reader.Align(16);
+
+        EmitterTranslationEffectRatio = reader.Read<float>();
+
+        LocusInterval = reader.Read<float>();
+
+        Field118 = reader.Read<int>();
+        Field11C = reader.Read<int>();
+        Field120 = reader.Read<int>();
+        Field124 = reader.Read<int>();
+        Field128 = reader.Read<int>();
+        Field12C = reader.Read<int>();
+        Field130 = reader.Read<int>();
+        Field134 = reader.Read<int>();
+        Field138 = reader.Read<int>();
+        Field13C = reader.Read<int>();
+
+        TextureIndexType = reader.Read<ETextureIndexType>();
+        TextureIndex = reader.Read<int>();
+        TextureIndexRangeStart = reader.Read<int>();
+        TextureIndexRangeEnd = reader.Read<int>();
+
+        Field150 = reader.Read<int>();
+        Field154 = reader.Read<int>();
+        Field158 = reader.Read<int>();
+        Field15C = reader.Read<int>();
+        Field160 = reader.Read<int>();
+        Field164 = reader.Read<float>();
+        Field168 = reader.Read<int>();
+        Field16C = reader.Read<int>();
+        Field170 = reader.Read<int>();
+        Field174 = reader.Read<int>();
+        Field178 = reader.Read<int>();
+        Field17C = reader.Read<int>();
+        Field180 = reader.Read<int>();
+        Field184 = reader.Read<int>();
+        Field188 = reader.Read<int>();
+        Field18C = reader.Read<int>();
+        Field190 = reader.Read<int>();
+        Field194 = reader.Read<int>();
+        Field198 = reader.Read<int>();
+        Field19C = reader.Read<int>();
+        Field1A0 = reader.Read<int>();
+
+        long materialOffset = reader.ReadOffsetValue();
+        if (materialOffset != 0)
+            Material = reader.ReadObjectAtOffset<MaterialParameter>(materialOffset);
+
+        BlendMode = reader.Read<EBlendMode>();
+        CompositeMode = reader.Read<ECompositeMode>();
+        SecondaryBlendMode = reader.Read<ESecondaryBlendMode>();
+        SecondaryBlend = reader.Read<int>();
+        TextureAddressMode = reader.Read<ETextureAddressMode>();
+
+        Field1BC = (int)reader.ReadOffsetValue();
+        if (ParticleType == EParticleType.Mesh && Field1BC != 0)
+            Mesh = reader.ReadObjectAtOffset<MeshParameter>(Field1BC);
+
+        Field1C0 = reader.Read<int>();
+        Field1C4 = reader.Read<int>();
+        Field1C8 = reader.Read<int>();
+        Field1CC = reader.Read<float>();
+        Field1D0 = reader.Read<float>();
+        Field1D4 = reader.Read<int>();
+        Field1D8 = reader.Read<float>();
+        Field1DC = reader.Read<int>();
+        Field1E0 = reader.Read<int>();
+        Field1E4 = reader.Read<int>();
+        Field1E8 = reader.Read<int>();
+        Field1EC = reader.Read<int>();
+
+        Flags = reader.Read<int>();
+
+        for (int i = 0; i < Animations.Capacity; i++)
+        {
+            Animations.Add(new());
+
+            long animationOffset = reader.ReadOffsetValue();
+            if (animationOffset != 0)
+                Animations[i] = reader.ReadObjectAtOffset<AnimationParameter>(animationOffset);
+        }
+
+        long nextOffset = reader.ReadOffsetValue();
+        if (nextOffset != 0)
+            parent.Particles.AddLast(reader.ReadObjectAtOffset<ParticleParameter>(nextOffset));
+    }
+
+    public void Write(BinaryObjectWriter writer, EmitterParameter parent)
+    {
+        writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+        writer.Write(ParticleType);
+
+        writer.Write(LifeTime);
+
+        writer.Write(ZOffset);
+
+        writer.Write(DirectionType);
+
+        writer.Write(Field14);
+
+        writer.Write(InitialSpeed);
+        writer.Write(InitialSpeedRandomMargin);
+        writer.Write(Deceleration);
+        writer.Write(DecelerationRandomMargin);
+        writer.Write(FollowEmitterTranslationRatio);
+        writer.Write(FollowEmitterTranslationYRatio);
+
+        writer.Write(BaseColor);
+        writer.Write(MultiPurposeColor);
+
+        writer.WriteOffset(() =>
+        {
+            foreach (var colorTable in ColorTables)
+                writer.Write(colorTable);
+        });
+        writer.Write(ColorTables.Count);
+
+        writer.WriteOffset(() =>
+        {
+            foreach (var colorTable2 in ColorTable2s)
+                writer.Write(colorTable2);
+        });
+        writer.Write(ColorTable2s.Count);
+
+        writer.Align(16);
+        writer.Write(InitialSize);
+        writer.Align(16);
+        writer.Write(InitialSizeRandomMargin);
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(InitialRotation));
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(InitialRotationRandomMargin));
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(Rotation));
+        writer.Align(16);
+        writer.Write(MathHelper.ToRadians(RotationRandomMargin));
+        writer.Align(16);
+        writer.Write(InitialDirection);
+        writer.Align(16);
+        writer.Write(InitialDirectionRandomMargin);
+        writer.Align(16);
+        writer.Write(GravitionalAcceleration);
+        writer.Align(16);
+        writer.Write(ExternalAcceleration);
+        writer.Align(16);
+        writer.Write(ExternalAccelerationRandomMargin);
+        writer.Align(16);
+
+        writer.Write(EmitterTranslationEffectRatio);
+        
+        writer.Write(LocusInterval);
+
+        writer.Write(Field118);
+        writer.Write(Field11C);
+        writer.Write(Field120);
+        writer.Write(Field124);
+        writer.Write(Field128);
+        writer.Write(Field12C);
+        writer.Write(Field130);
+        writer.Write(Field134);
+        writer.Write(Field138);
+        writer.Write(Field13C);
+
+        writer.Write(TextureIndexType);
+        writer.Write(TextureIndex);
+        writer.Write(TextureIndexRangeStart);
+        writer.Write(TextureIndexRangeEnd);
+
+        writer.Write(Field150);
+        writer.Write(Field154);
+        writer.Write(Field158);
+        writer.Write(Field15C);
+        writer.Write(Field160);
+        writer.Write(Field164);
+        writer.Write(Field168);
+        writer.Write(Field16C);
+        writer.Write(Field170);
+        writer.Write(Field174);
+        writer.Write(Field178);
+        writer.Write(Field17C);
+        writer.Write(Field180);
+        writer.Write(Field184);
+        writer.Write(Field188);
+        writer.Write(Field18C);
+        writer.Write(Field190);
+        writer.Write(Field194);
+        writer.Write(Field198);
+        writer.Write(Field19C);
+        writer.Write(Field1A0);
+
+        if (Material != null)
+            writer.WriteObjectOffset(Material);
+        else
+            writer.WriteOffsetValue(0);
+
+        writer.Write(BlendMode);
+        writer.Write(CompositeMode);
+        writer.Write(SecondaryBlendMode);
+        writer.Write(SecondaryBlend);
+        writer.Write(TextureAddressMode);
+
+        if (ParticleType == EParticleType.Mesh && Mesh != null)
+            writer.WriteObjectOffset(Mesh);
+        else
+            writer.WriteOffsetValue(Field1BC);
+
+        writer.Write(Field1C0);
+        writer.Write(Field1C4);
+        writer.Write(Field1C8);
+        writer.Write(Field1CC);
+        writer.Write(Field1D0);
+        writer.Write(Field1D4);
+        writer.Write(Field1D8);
+        writer.Write(Field1DC);
+        writer.Write(Field1E0);
+        writer.Write(Field1E4);
+        writer.Write(Field1E8);
+        writer.Write(Field1EC);
+
+        writer.Write(Flags);
+
+        foreach (var animation in Animations)
+        {
+            if (animation.Keyframes.Count != 0)
+                writer.WriteObjectOffset(animation);
+            else
+                writer.WriteOffsetValue(0);
+        }
+
+        if (parent.Particles.Find(this).Next != null)
+            writer.WriteObjectOffset(parent.Particles.Find(this).Next.Value, parent, 16);
+        else
+            writer.WriteOffsetValue(0);
+    }
+
+    public enum EParticleType : int
+    {
+        Quad,
+        Mesh,
+        Locus
+    }
+
+    public enum EDirectionType : int
+    {
+        Billboard,
+        DirectionalAngleBillboard = 2
+    }
+
+    public enum ETextureIndexType : int
+    {
+        Fixed,
+    }
+
+    public enum EBlendMode : int
+    {
+        UseMaterial = -1,
+    }
+
+    public enum ECompositeMode : int
+    {
+        UseMaterial = -1,
+    }
+
+    public enum ESecondaryBlendMode : int
+    {
+        UseMaterial = -1,
+    }
+
+    public enum ETextureAddressMode : int
+    {
+        UseMaterial = -1,
+    }
+
+    public class MeshParameter : IBinarySerializable
+    {
+        public string Name { get; set; }
+
+        public void Read(BinaryObjectReader reader)
+        {
+            Name = reader.ReadStringOffset();
+        }
+
+        public void Write(BinaryObjectWriter writer)
+        {
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+        }
+    }
+}

--- a/Source/SharpNeedle/Utilities/MathHelper.cs
+++ b/Source/SharpNeedle/Utilities/MathHelper.cs
@@ -175,4 +175,34 @@ public static class MathHelper
             MathF.Asin(2.0f * test / unit),
             MathF.Atan2(2.0f * (quaternion.X * quaternion.W + quaternion.Y * quaternion.Z), -sqx + sqy - sqz + sqw));
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float ToDegrees(this float radian)
+    {
+        return radian * 180.0f / MathF.PI;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static float ToRadians(this float degree)
+    {
+        return degree * MathF.PI / 180.0f;
+    }
+    
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static Vector3 ToRadians(this Vector3 degreeVector)
+    {
+        return new Vector3(
+            degreeVector.X.ToRadians(),
+            degreeVector.Y.ToRadians(),
+            degreeVector.Z.ToRadians());
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining | MethodImplOptions.AggressiveOptimization)]
+    public static Vector3 ToDegrees(this Vector3 radianVector)
+    {
+        return new Vector3(
+            radianVector.X.ToDegrees(),
+            radianVector.Y.ToDegrees(),
+            radianVector.Z.ToDegrees());
+    }
 }


### PR DESCRIPTION
Adds support for the Glitter effect files found in Mario & Sonic at the 2014 Sochi Olympic Games (.gle) and Sonic Lost World (.effect).

Writing is untested at the moment due to HedgeArcPack issue with packing newly created effect files.