### PR TITLE
Add support for the .mlevel file found in Sonic Frontiers

### DIFF
--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -1,7 +1,5 @@
-﻿namespace SharpNeedle.SonicTeam; 
-
-using SharpNeedle.BINA;
-using System.Reflection.PortableExecutable;
+﻿namespace SharpNeedle.SonicTeam;
+using BINA;
 
 [NeedleResource("st/masterlevel", @"\.mlevel$")]
 public class MasterLevel : BinaryResource
@@ -183,7 +181,7 @@ public class MasterLevel : BinaryResource
         {
             reader.Align(8);
 
-            Name = reader.ReadStringOffset(StringBinaryFormat.NullTerminated);
+            Name = reader.ReadStringOffset();
 
             if (options.IsDependency)
             {
@@ -237,7 +235,7 @@ public class MasterLevel : BinaryResource
 
             if (!options.IsLastLevel)
             {
-                if (String.IsNullOrEmpty(NextDependencyName))
+                if (string.IsNullOrEmpty(NextDependencyName))
                 {
                     if (NextFileInfo == null)
                     {

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -54,8 +54,8 @@ public class MasterLevel : BinaryResource
     public class LevelInfo : IBinarySerializable
     {
         public string Name { get; set; }
-        public bool HasFilesAndDependencies { get; set; }
         public bool HasFiles { get; set; }
+        public bool Field20 { get; set; }
         public List<FileInfo> Files { get; set; } = new();
         public List<FileInfo> Dependencies { get; set; } = new(); // Guessed
 
@@ -96,7 +96,7 @@ public class MasterLevel : BinaryResource
                 }
             });
 
-            HasFilesAndDependencies = reader.Read<bool>();
+            Field20 = reader.Read<bool>();
             HasFiles = reader.Read<bool>();
 
             reader.Align(8);
@@ -134,7 +134,7 @@ public class MasterLevel : BinaryResource
                 }
             });
 
-            writer.Write(HasFilesAndDependencies);
+            writer.Write(Field20);
             writer.Write(HasFiles);
 
             writer.Align(8);
@@ -193,7 +193,7 @@ public class MasterLevel : BinaryResource
 
             if (String.IsNullOrEmpty(NextDependencyName))
             {
-                if (String.IsNullOrEmpty(NextFileInfo.Name))
+                if (NextFileInfo == null)
                 {
                     writer.WriteOffsetValue(0);
                 }

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -103,7 +103,7 @@ public class MasterLevel : BinaryResource
 
                     for (int i = 0; i < dependencyCount; i++)
                     {
-                        options.IsLast = i + 1 == Dependencies.Count;
+                        fileOptions.IsLast = i + 1 == dependencyCount;
 
                         reader.ReadOffset(() =>
                         {
@@ -130,7 +130,7 @@ public class MasterLevel : BinaryResource
             Files = Files.OrderBy(o => o.Name).ToList();
             Dependencies = Dependencies.OrderBy(o => o.Name).ToList();
 
-            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name, writer.GetOffsetSize());
 
             writer.Write(Files.Count);
             writer.Write(Dependencies.Count);
@@ -153,7 +153,7 @@ public class MasterLevel : BinaryResource
 
                 for (int i = 0; i < Dependencies.Count; i++)
                 {
-                    options.IsLast = i + 1 == Dependencies.Count;
+                    fileOptions.IsLast = i + 1 == Dependencies.Count;
 
                     writer.WriteObjectOffset(Dependencies[i], fileOptions, writer.GetOffsetSize());
                 }
@@ -219,7 +219,7 @@ public class MasterLevel : BinaryResource
         {
             writer.Align(8);
 
-            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name, writer.GetOffsetSize());
 
             if (options.IsDependency)
             {
@@ -243,12 +243,12 @@ public class MasterLevel : BinaryResource
                     }
                     else
                     {
-                        writer.WriteObjectOffset(NextFileInfo);
+                        writer.WriteObjectOffset(NextFileInfo, writer.GetOffsetSize());
                     }
                 }
                 else
                 {
-                    writer.WriteStringOffset(StringBinaryFormat.NullTerminated, NextDependencyName);
+                    writer.WriteStringOffset(StringBinaryFormat.NullTerminated, NextDependencyName, writer.GetOffsetSize());
                 }
             }
         }

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -50,11 +50,11 @@ public class MasterLevel : BinaryResource
     public class LevelInfo : IBinarySerializable
     {
         public string Name { get; set; }
-        public List<FileInfo> Files { get; set; } = new();
-        public List<FileInfo> Dependencies { get; set; } = new(); // Guessed
         public bool Field20 { get; set; }
         public bool Field21 { get; set; }
         public long Field28 { get; set; }
+        public List<FileInfo> Files { get; set; } = new();
+        public List<FileInfo> Dependencies { get; set; } = new(); // Guessed
 
         public void Read(BinaryObjectReader reader)
         {

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -9,10 +9,13 @@ public class MasterLevel : BinaryResource
     public new static readonly uint Signature = BinaryHelper.MakeSignature<uint>("LMEH");
     public List<LevelInfo> Levels { get; set; } = new();
 
+    public MasterLevel()
+    {
+        Version = new Version(2, 1, 0, BinaryHelper.PlatformEndianness);
+    }
+
     public override void Read(BinaryObjectReader reader)
     {
-        reader.OffsetBinaryFormat = OffsetBinaryFormat.U64;
-
         reader.EnsureSignature(Signature);
 
         reader.Align(reader.GetOffsetSize()); // 4 empty bytes, always 0(?). Very Likely Padding or Version
@@ -36,7 +39,6 @@ public class MasterLevel : BinaryResource
 
     public override void Write(BinaryObjectWriter writer)
     {
-        writer.OffsetBinaryFormat = OffsetBinaryFormat.U64;
         Levels = Levels.OrderBy(o => o.Name).ToList();
 
         writer.Write(Signature);

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -1,0 +1,169 @@
+﻿namespace SharpNeedle.SonicTeam; 
+
+using SharpNeedle.BINA;
+
+[NeedleResource("st/masterlevel", @"\.mlevel$")]
+public class MasterLevel : BinaryResource
+{
+    public new static readonly uint Signature = BinaryHelper.MakeSignature<uint>("LMEH");
+    public int Field04 { get; set; }
+    public List<LevelInfo> Levels { get; set; } = new();
+
+    public override void Read(BinaryObjectReader reader)
+    {
+        reader.OffsetBinaryFormat = OffsetBinaryFormat.U64;
+
+        reader.EnsureSignature(Signature);
+
+        Field04 = reader.Read<int>(); // Always 0? Potentially Padding or Version
+
+        var levelCount = reader.ReadOffsetValue();
+        reader.ReadOffset(() =>
+        {
+            for (int i = 0; i < levelCount; i++)
+                Levels.Add(reader.ReadObjectOffset<LevelInfo>());
+        });
+
+
+        reader.Align(16);
+    }
+
+    public override void Write(BinaryObjectWriter writer)
+    {
+        writer.OffsetBinaryFormat = OffsetBinaryFormat.U64;
+
+        writer.Write(Signature);
+        writer.Write(Field04);
+
+        Levels = Levels.OrderBy(o => o.Name).ToList();
+
+        writer.Write<long>(Levels.Count);
+        writer.WriteOffset(() =>
+        {
+            for (int i = 0; i < Levels.Count; i++)
+                writer.WriteObjectOffset(Levels[i], 8);
+        });
+
+        writer.Align(16);
+    }
+
+    public class LevelInfo : IBinarySerializable
+    {
+        public string Name { get; set; }
+        public List<FileInfo> Files { get; set; } = new();
+        public List<FileInfo> Dependencies { get; set; } = new(); // Guessed
+        public bool Field20 { get; set; }
+        public bool Field21 { get; set; }
+        public long Field28 { get; set; }
+
+        public void Read(BinaryObjectReader reader)
+        {
+            reader.Align(8);
+
+            Name = reader.ReadStringOffset(StringBinaryFormat.NullTerminated);
+
+            int fileCount = reader.Read<int>();
+            int dependencyCount = reader.Read<int>();
+
+            reader.ReadOffset(() =>
+            {
+                if (fileCount != 0)
+                {
+                    for (int i = 0; i < fileCount; i++)
+                    {
+                        reader.ReadOffset(() =>
+                        {
+                            Files.Add(reader.ReadObject<FileInfo>());
+                        });
+                    }
+                }
+            });
+
+            reader.ReadOffset(() =>
+            {
+                if (dependencyCount != 0)
+                {
+                    for (int i = 0; i < dependencyCount; i++)
+                    {
+                        reader.ReadOffset(() =>
+                        {
+                            Dependencies.Add(reader.ReadObject<FileInfo>());
+                        });
+                    }
+                }
+            });
+
+            Field20 = reader.Read<bool>();
+            Field21 = reader.Read<bool>();
+            Field28 = reader.ReadOffsetValue();
+        }
+
+        public void Write(BinaryObjectWriter writer)
+        {
+            writer.Align(8);
+
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+            Files = Files.OrderBy(o => o.Name).ToList();
+            Dependencies = Dependencies.OrderBy(o => o.Name).ToList();
+
+            writer.Write(Files.Count);
+            writer.Write(Dependencies.Count);
+
+            writer.WriteOffset(() =>
+            {
+                for (int i = 0; i < Files.Count; i++)
+                {
+                    writer.WriteObjectOffset(Files[i], 8);
+                }
+            });
+
+            writer.WriteOffset(() =>
+            {
+                for (int i = 0; i < Dependencies.Count; i++)
+                {
+                    writer.WriteObjectOffset(Dependencies[i], 8);
+                }
+            });
+
+            writer.Write(Field20);
+            writer.Write(Field21);
+            writer.Write(Field28);
+        }
+    }
+
+    public class FileInfo : IBinarySerializable
+    {
+        public string Name { get; set; }
+        public bool Field08 { get; set; }
+        public long Field10 { get; set; }
+
+        public void Read(BinaryObjectReader reader)
+        {
+            reader.Align(8);
+
+            Name = reader.ReadStringOffset(StringBinaryFormat.NullTerminated);
+
+            reader.ReadOffset(() =>
+            {
+                Field08 = reader.Read<bool>();
+            });
+
+            Field10 = reader.ReadOffsetValue();
+        }
+
+        public void Write(BinaryObjectWriter writer)
+        {
+            writer.Align(8);
+
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+
+            writer.WriteOffset(() =>
+            {
+                writer.Write(Field08);
+            });
+
+            writer.Write(Field10);
+        }
+    }
+}

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -99,7 +99,11 @@ public class MasterLevel : BinaryResource
             HasFilesAndDependencies = reader.Read<bool>();
             HasFiles = reader.Read<bool>();
 
-            reader.Align(16);
+            reader.Align(8);
+
+            reader.Skip(8); // Potential Runtime Field
+
+            reader.Align(8);
         }
 
         public void Write(BinaryObjectWriter writer)
@@ -133,7 +137,11 @@ public class MasterLevel : BinaryResource
             writer.Write(HasFilesAndDependencies);
             writer.Write(HasFiles);
 
-            writer.Align(16);
+            writer.Align(8);
+
+            writer.Skip(8); // Potential Runtime Field
+
+            writer.Align(8);
         }
     }
 

--- a/Source/SharpNeedle/SonicTeam/MasterLevel.cs
+++ b/Source/SharpNeedle/SonicTeam/MasterLevel.cs
@@ -54,8 +54,8 @@ public class MasterLevel : BinaryResource
     public class LevelInfo : IBinarySerializable
     {
         public string Name { get; set; }
-        public bool Field20 { get; set; }
-        public bool Field21 { get; set; }
+        public bool HasFilesAndDependencies { get; set; }
+        public bool HasFiles { get; set; }
         public List<FileInfo> Files { get; set; } = new();
         public List<FileInfo> Dependencies { get; set; } = new(); // Guessed
 
@@ -96,8 +96,8 @@ public class MasterLevel : BinaryResource
                 }
             });
 
-            Field20 = reader.Read<bool>();
-            Field21 = reader.Read<bool>();
+            HasFilesAndDependencies = reader.Read<bool>();
+            HasFiles = reader.Read<bool>();
 
             reader.Align(16);
         }
@@ -130,8 +130,8 @@ public class MasterLevel : BinaryResource
                 }
             });
 
-            writer.Write(Field20);
-            writer.Write(Field21);
+            writer.Write(HasFilesAndDependencies);
+            writer.Write(HasFiles);
 
             writer.Align(16);
         }


### PR DESCRIPTION
The written file has not been tested outside of it being parsed correctly by my 010 editor template for the file as it is impossible to repack the file at the current time.