### PR TITLE
Fix big endian writing of TerrainMaterial and PointCloud

### DIFF
--- a/Source/SharpNeedle/SonicTeam/PointCloud.cs
+++ b/Source/SharpNeedle/SonicTeam/PointCloud.cs
@@ -16,7 +16,6 @@ public class PointCloud : BinaryResource
     public override void Read(BinaryObjectReader reader)
     {
         reader.EnsureSignature(Signature);
-
         FormatVersion = reader.Read<uint>();
 
         var instancesOffset = reader.ReadOffsetValue();
@@ -33,8 +32,7 @@ public class PointCloud : BinaryResource
 
     public override void Write(BinaryObjectWriter writer)
     {
-        writer.WriteNative(Signature);
-
+        writer.Write(Signature);
         writer.Write(FormatVersion);
 
         writer.WriteOffset(() =>

--- a/Source/SharpNeedle/SonicTeam/TerrainMaterial.cs
+++ b/Source/SharpNeedle/SonicTeam/TerrainMaterial.cs
@@ -16,7 +16,6 @@ public class TerrainMaterial : BinaryResource
     public override void Read(BinaryObjectReader reader)
     {
         reader.EnsureSignature(Signature);
-
         FormatVersion = reader.Read<uint>();
 
         var instancesOffset = reader.ReadOffsetValue();
@@ -30,8 +29,7 @@ public class TerrainMaterial : BinaryResource
 
     public override void Write(BinaryObjectWriter writer)
     {
-        writer.WriteNative(Signature);
-
+        writer.Write(Signature);
         writer.Write(FormatVersion);
 
         writer.WriteObjectCollectionOffset(Layers);


### PR DESCRIPTION
Fixes TerrainMaterial's and PointCloud's signatures being always written as little-endian. 
Even though big-endian variants of these formats aren't used, I feel like it's worth the change just to be more consistent with the API.