### PR TITLE
Add support for SHLightField

### DIFF
--- a/Source/SharpNeedle/SonicTeam/SHLightField.cs
+++ b/Source/SharpNeedle/SonicTeam/SHLightField.cs
@@ -8,7 +8,7 @@ using Utilities;
 public class SHLightField : BinaryResource
 {
     public uint FormatVersion { get; set; } = 1;
-    public float[] Field04 { get; set; } = new float[36];
+    public float[] DefaultProbeLightingData { get; set; } = new float[36];
     public List<Node> Nodes { get; set; } = new ();
 
     public SHLightField()
@@ -21,7 +21,7 @@ public class SHLightField : BinaryResource
         bool inMeters = Path.GetExtension(BaseFile.Name) == ".lf";
 
         FormatVersion = reader.Read<uint>();
-        reader.ReadArray<float>(36, Field04);
+        reader.ReadArray<float>(36, DefaultProbeLightingData);
 
         int probeCount = reader.Read<int>();
         Nodes.AddRange(reader.ReadObjectArrayOffset<Node, bool>(inMeters, probeCount));
@@ -32,7 +32,7 @@ public class SHLightField : BinaryResource
         bool inMeters = Path.GetExtension(BaseFile.Name) == ".lf";
 
         writer.Write(FormatVersion);
-        writer.WriteArrayFixedLength(Field04, 36);
+        writer.WriteArrayFixedLength(DefaultProbeLightingData, 36);
 
         writer.Write(Nodes.Count);
         writer.WriteObjectCollectionOffset(inMeters, Nodes);
@@ -58,9 +58,9 @@ public class SHLightField : BinaryResource
             ProbeCountY = reader.Read<int>();
             ProbeCountZ = reader.Read<int>();
 
-            Position = inMeters ? reader.Read<Vector3>() * 10 : reader.Read<Vector3>();
+            Position = inMeters ? reader.Read<Vector3>() : reader.Read<Vector3>() / 10;
             Rotation = reader.Read<Vector3>();
-            Scale = inMeters ? reader.Read<Vector3>() * 10 : reader.Read<Vector3>();
+            Scale = inMeters ? reader.Read<Vector3>() : reader.Read<Vector3>() / 10;
         }
 
         public void Write(BinaryObjectWriter writer, bool inMeters = false)
@@ -71,9 +71,9 @@ public class SHLightField : BinaryResource
             writer.Write(ProbeCountY);
             writer.Write(ProbeCountZ);
 
-            writer.Write(inMeters ? Position / 10 : Position);
+            writer.Write(inMeters ? Position : Position * 10);
             writer.Write(Rotation);
-            writer.Write(inMeters ? Scale / 10 : Scale);
+            writer.Write(inMeters ? Scale : Scale * 10);
         }
     }
 }

--- a/Source/SharpNeedle/SonicTeam/SHLightField.cs
+++ b/Source/SharpNeedle/SonicTeam/SHLightField.cs
@@ -1,0 +1,79 @@
+namespace SharpNeedle.SonicTeam;
+
+using System.IO;
+using BINA;
+using Utilities;
+
+[NeedleResource("st/shlf", @"\.(sh?)lf$")]
+public class SHLightField : BinaryResource
+{
+    public uint FormatVersion { get; set; } = 1;
+    public float[] Field04 { get; set; } = new float[36];
+    public List<Node> Nodes { get; set; } = new ();
+
+    public SHLightField()
+    {
+        Version = new Version(2, 1, 0, BinaryHelper.PlatformEndianness);
+    }
+
+    public override void Read(BinaryObjectReader reader)
+    {
+        bool inMeters = Path.GetExtension(BaseFile.Name) == ".lf";
+
+        FormatVersion = reader.Read<uint>();
+        reader.ReadArray<float>(36, Field04);
+
+        int probeCount = reader.Read<int>();
+        Nodes.AddRange(reader.ReadObjectArrayOffset<Node, bool>(inMeters, probeCount));
+    }
+
+    public override void Write(BinaryObjectWriter writer)
+    {
+        bool inMeters = Path.GetExtension(BaseFile.Name) == ".lf";
+
+        writer.Write(FormatVersion);
+        writer.WriteArrayFixedLength(Field04, 36);
+
+        writer.Write(Nodes.Count);
+        writer.WriteObjectCollectionOffset(inMeters, Nodes);
+    }
+
+    public class Node : IBinarySerializable<bool>
+    {
+        public string Name { get; set; }
+
+        public int ProbeCountX { get; set; }
+        public int ProbeCountY { get; set; }
+        public int ProbeCountZ { get; set; }
+
+        public Vector3 Position { get; set; }
+        public Vector3 Rotation { get; set; }
+        public Vector3 Scale { get; set; }
+
+        public void Read(BinaryObjectReader reader, bool inMeters = false)
+        {
+            Name = reader.ReadStringOffset(StringBinaryFormat.NullTerminated);
+
+            ProbeCountX = reader.Read<int>();
+            ProbeCountY = reader.Read<int>();
+            ProbeCountZ = reader.Read<int>();
+
+            Position = inMeters ? reader.Read<Vector3>() * 10 : reader.Read<Vector3>();
+            Rotation = reader.Read<Vector3>();
+            Scale = inMeters ? reader.Read<Vector3>() * 10 : reader.Read<Vector3>();
+        }
+
+        public void Write(BinaryObjectWriter writer, bool inMeters = false)
+        {
+            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name, -1, 1);
+
+            writer.Write(ProbeCountX);
+            writer.Write(ProbeCountY);
+            writer.Write(ProbeCountZ);
+
+            writer.Write(inMeters ? Position / 10 : Position);
+            writer.Write(Rotation);
+            writer.Write(inMeters ? Scale / 10 : Scale);
+        }
+    }
+}

--- a/Source/SharpNeedle/Utilities/BinaryHelper.cs
+++ b/Source/SharpNeedle/Utilities/BinaryHelper.cs
@@ -197,4 +197,15 @@ public static class BinaryHelper
 
     public static SeekToken At(this BinaryValueWriter reader)
         => new SeekToken(reader.GetBaseStream(), reader.Position, SeekOrigin.Begin);
+
+	public static void WriteArrayFixedLength<T>(this BinaryObjectWriter writer, Span<T> array, int length) where T : unmanaged
+    {
+        if (array.Length != length)
+            throw new IndexOutOfRangeException($"Fixed array length mismatch. Expected: {length}. Got: {array.Length}");
+
+        writer.WriteArray((ReadOnlySpan<T>)array);
+    }
+
+    public static void WriteArrayFixedLength<T>(this BinaryObjectWriter writer, T[] array, int length) where T : unmanaged
+        => WriteArrayFixed(writer, array.AsSpan(), length);
 }


### PR DESCRIPTION
Adds support for reading/writing Spherical Harmonics Light Field files (shlf / lf), as well as a new function to BinaryHelpers.cs for ensuring a written array's length is fixed.

Based on Skyth's <a href = https://github.com/blueskythlikesclouds/HedgeGI/blob/master/Source/HedgeGI/hl_hh_shlf.h>HedgeGI</a>.