### PR TITLE
Remove Amicitia.IO submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,1 @@
-[submodule "Source/Dependencies/Amicitia.IO"]
-	path = Source/Dependencies/Amicitia.IO
-	url = https://github.com/TGEnigma/Amicitia.IO
+


### PR DESCRIPTION
Since #27 replaced it with a NuGet package, it's no longer used as a submodule.