### PR TITLE
Improve YNCP writing.

### DIFF
--- a/Source/SharpNeedle/Framework/Ninja/Csd/CastInfo.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/CastInfo.cs
@@ -15,9 +15,9 @@ public struct CastInfo : IBinarySerializable
     public Color<byte> GradientBottomLeft;
     public Color<byte> GradientTopRight;
     public Color<byte> GradientBottomRight;
-    public uint Field30;
-    public uint Field34;
-    public uint Field38;
+    public uint UserData0;
+    public uint UserData1;
+    public uint UserData2;
 
     public void Read(BinaryObjectReader reader)
     {
@@ -34,9 +34,9 @@ public struct CastInfo : IBinarySerializable
         Unsafe.As<Color<byte>, uint>(ref GradientTopRight) = reader.Read<uint>();
         Unsafe.As<Color<byte>, uint>(ref GradientBottomRight) = reader.Read<uint>();
 
-        Field30 = reader.Read<uint>();
-        Field34 = reader.Read<uint>();
-        Field38 = reader.Read<uint>();
+        UserData0 = reader.Read<uint>();
+        UserData1 = reader.Read<uint>();
+        UserData2 = reader.Read<uint>();
     }
 
     public void Write(BinaryObjectWriter writer)
@@ -54,8 +54,8 @@ public struct CastInfo : IBinarySerializable
         writer.Write(Unsafe.As<Color<byte>, uint>(ref GradientTopRight));
         writer.Write(Unsafe.As<Color<byte>, uint>(ref GradientBottomRight));
 
-        writer.Write(Field30);
-        writer.Write(Field34);
-        writer.Write(Field38);
+        writer.Write(UserData0);
+        writer.Write(UserData1);
+        writer.Write(UserData2);
     }
 }

--- a/Source/SharpNeedle/Framework/Ninja/Csd/CastInfoTable.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/CastInfoTable.cs
@@ -35,7 +35,11 @@ public class CastInfoTable : List<(string? Name, int FamilyIdx, int CastIdx)>, I
         {
             foreach ((string? Name, int FamilyIdx, int CastIdx) in this)
             {
-                writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+                writer.WriteOffset(() => 
+                {
+                    writer.WriteString(StringBinaryFormat.NullTerminated, Name);
+                    writer.Write<byte>(0);
+                });
                 writer.Write(FamilyIdx);
                 writer.Write(CastIdx);
             }

--- a/Source/SharpNeedle/Framework/Ninja/Csd/CsdDictionary.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/CsdDictionary.cs
@@ -237,7 +237,13 @@ public class CsdDictionary<T> : IBinarySerializable, IDictionary<string?, T> whe
 
         public void Write(BinaryObjectWriter writer)
         {
-            writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+            string? name = Name;
+
+            writer.WriteOffset(() => 
+            {
+                writer.WriteString(StringBinaryFormat.NullTerminated, name);
+                writer.Write<byte>(0);
+            });
             writer.Write(ref Index);
         }
 

--- a/Source/SharpNeedle/Framework/Ninja/Csd/Motions/CastMotion.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/Motions/CastMotion.cs
@@ -66,26 +66,32 @@ public class CastMotion : List<KeyFrameList>, IBinarySerializable
     public void ReadExtended(BinaryObjectReader reader)
     {
         reader.ReadOffset(() =>
-        {
-            foreach (KeyFrameList list in this)
+            reader.ReadOffset(() => 
             {
-                list.ReadExtended(reader);
-            }
-        });
+                foreach (KeyFrameList list in this)
+                {
+                    list.ReadExtended(reader);
+                }
+            }));
     }
 
     public void WriteExtended(BinaryObjectWriter writer)
     {
         writer.WriteOffset(() =>
-        {
-            if (Count == 0)
+        { 
+            if (Count != 0)
+            { 
+                writer.WriteOffset(() => 
+                {
+                    foreach (KeyFrameList list in this)
+                    {
+                        list.WriteExtended(writer);
+                    }
+                });
+            }
+            else
             {
                 writer.WriteOffsetValue(0);
-            }
-
-            foreach (KeyFrameList list in this)
-            {
-                list.WriteExtended(writer);
             }
         });
     }

--- a/Source/SharpNeedle/Framework/Ninja/Csd/Motions/FamilyMotion.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/Motions/FamilyMotion.cs
@@ -70,25 +70,25 @@ public class FamilyMotion : IBinarySerializable
 
     public void ReadExtended(BinaryObjectReader reader)
     {
-        int unused = reader.Read<int>();
-        reader.ReadOffset(() => reader.ReadOffset(() => reader.ReadOffset(() =>
+        reader.ReadOffset(() => 
+            reader.ReadOffset(() =>
+            {
+                foreach (CastMotion motion in CastMotions)
                 {
-                    foreach (CastMotion motion in CastMotions)
-                    {
-                        motion.ReadExtended(reader);
-                    }
-                })));
+                    motion.ReadExtended(reader);
+                }
+            }));
     }
 
     public void WriteExtended(BinaryObjectWriter writer)
     {
-        writer.Write(0);
-        writer.WriteOffset(() => writer.WriteOffset(() => writer.WriteOffset(() =>
+        writer.WriteOffset(() =>
+            writer.WriteOffset(() =>
+            {
+                foreach (CastMotion motion in CastMotions)
                 {
-                    foreach (CastMotion motion in CastMotions)
-                    {
-                        motion.WriteExtended(writer);
-                    }
-                })));
+                    motion.WriteExtended(writer);
+                }
+            }));
     }
 }

--- a/Source/SharpNeedle/Framework/Ninja/Csd/Motions/KeyFrame.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/Motions/KeyFrame.cs
@@ -4,7 +4,7 @@ using SharpNeedle.Structs;
 
 public class KeyFrame : IBinarySerializable
 {
-    public uint Frame { get; set; }
+    public int Frame { get; set; }
     public Union Value { get; set; }
     public InterpolationType Interpolation { get; set; }
     public float InTangent { get; set; }
@@ -14,7 +14,7 @@ public class KeyFrame : IBinarySerializable
 
     public void Read(BinaryObjectReader reader)
     {
-        Frame = reader.Read<uint>();
+        Frame = reader.Read<int>();
         Value = reader.Read<uint>();
         Interpolation = reader.Read<InterpolationType>();
         InTangent = reader.Read<float>();

--- a/Source/SharpNeedle/Framework/Ninja/Csd/Motions/Motion.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/Motions/Motion.cs
@@ -80,10 +80,15 @@ public class Motion : IBinarySerializable
     {
         reader.ReadOffset(() =>
         {
-            foreach (FamilyMotion motion in FamilyMotions)
-            {
-                motion.ReadExtended(reader);
-            }
+            int unused = reader.Read<int>();
+
+            reader.ReadOffset(() =>
+            { 
+                foreach (FamilyMotion motion in FamilyMotions)
+                {
+                    motion.ReadExtended(reader);
+                }
+            });
         });
     }
 
@@ -91,10 +96,15 @@ public class Motion : IBinarySerializable
     {
         writer.WriteOffset(() =>
         {
-            foreach (FamilyMotion motion in FamilyMotions)
-            {
-                motion.WriteExtended(writer);
-            }
+            writer.Write(0);
+
+            writer.WriteOffset(() =>
+            { 
+                foreach (FamilyMotion motion in FamilyMotions)
+                {
+                    motion.WriteExtended(writer);
+                }
+            });
         });
     }
 }

--- a/Source/SharpNeedle/Framework/Ninja/Csd/ProjectChunk.cs
+++ b/Source/SharpNeedle/Framework/Ninja/Csd/ProjectChunk.cs
@@ -35,7 +35,7 @@ public class ProjectChunk : IChunk
         writer.Write(Field08);
         writer.Write(Field0C);
         writer.WriteObjectOffset(Root);
-        writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Name);
+        writer.WriteOffset(() => writer.WriteString(StringBinaryFormat.NullTerminated, Name));
         writer.Write(TextureFormat);
         writer.WriteObjectOffset(Fonts);
         writer.Flush();


### PR DESCRIPTION
Gets YNCP writing to be nearly identical to the original, with differences being:
- File padding at the end.
- Garbage characters after every null terminated string.
- End frames of motions.
- Unpreserved original cast dictionary order when sorting by the name and having identical cast names.

Closes #44.
Closes #43.