### PR TITLE
Sample Chunk Resource v2 fallback reader

### DIFF
--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ArchiveInfo.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ArchiveInfo.cs
@@ -40,6 +40,11 @@ public class ArchiveInfo : SampleChunkResource
         });
     }
 
+    protected override void Reset()
+    {
+        Entries.Clear();
+    }
+
     public class Entry : IBinarySerializable
     {
         public string? Name { get; set; }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/GIMipLevelLimitation.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/GIMipLevelLimitation.cs
@@ -24,6 +24,13 @@ public class GIMipLevelLimitation : SampleChunkResource
         writer.Align(4);
     }
 
+    protected override void Reset()
+    {
+        Level0 = default;
+        Level1 = default;
+        Level2 = default;
+    }
+
     public bool this[int index]
     {
         get

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/GITextureGroupInfo.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/GITextureGroupInfo.cs
@@ -94,4 +94,11 @@ public class GITextureGroupInfo : SampleChunkResource
             }
         });
     }
+
+    protected override void Reset()
+    {
+        Instances.Clear();
+        Groups.Clear();
+        LowQualityGroups.Clear();
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/Light.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/Light.cs
@@ -57,4 +57,13 @@ public class Light : SampleChunkResource
                 break;
         }
     }
+
+    protected override void Reset()
+    {
+        Type = default;
+        Attribute = default;
+        Position = default;
+        Color = default;
+        Range = default;
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/LightFieldTree.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/LightFieldTree.cs
@@ -38,6 +38,14 @@ public class LightFieldTree : SampleChunkResource
         writer.Write(Indices.Count);
         writer.WriteCollectionOffset(Indices);
     }
+
+    protected override void Reset()
+    {
+        Bounds = default;
+        Cells.Clear();
+        Probes.Clear();
+        Indices.Clear();
+    }
 }
 
 public class LightFieldCell : IBinarySerializable

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/LightList.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/LightData/LightList.cs
@@ -30,6 +30,11 @@ public class LightList : SampleChunkResource
         });
     }
 
+    protected override void Reset()
+    {
+        Lights.Clear();
+    }
+
     public override void WriteDependencies(IDirectory dir)
     {
         if (Lights == null)

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/MaterialData/Material.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/MaterialData/Material.cs
@@ -197,6 +197,18 @@ public class Material : SampleChunkResource
         }
     }
 
+    protected override void Reset()
+    {
+        ShaderName = default;
+        AlphaThreshold = default;
+        NoBackFaceCulling = default;
+        BlendMode = default;
+        FloatParameters.Clear();
+        IntParameters.Clear();
+        BoolParameters.Clear();
+        Texset = new();
+    }
+
     public override void ResolveDependencies(IResourceResolver resolver)
     {
         if (DataVersion <= 1)

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/MaterialData/Texset.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/MaterialData/Texset.cs
@@ -31,6 +31,11 @@ public class Texset : SampleChunkResource
         });
     }
 
+    protected override void Reset()
+    {
+        Textures.Clear();
+    }
+
     public override void ResolveDependencies(IResourceResolver resolver)
     {
         List<string> exception = [];

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/MaterialData/Texture.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/MaterialData/Texture.cs
@@ -34,4 +34,13 @@ public class Texture : SampleChunkResource
         writer.Align(4);
         writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Type);
     }
+
+    protected override void Reset()
+    {
+        PictureName = default;
+        TexCoordIndex = default;
+        WrapModeU = default;
+        WrapModeV = default;
+        Type = default;
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/Model.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/Model.cs
@@ -92,6 +92,14 @@ public class Model : ModelBase
         }
     }
 
+    protected override void Reset()
+    {
+        base.Reset();
+        Morphs = null;
+        Nodes.Clear();
+        Bounds = default;
+    }
+
     public override void ResolveDependencies(IResourceResolver resolver)
     {
         base.ResolveDependencies(resolver);

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/ModelBase.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/ModelBase.cs
@@ -6,6 +6,11 @@ public abstract class ModelBase : SampleChunkResource
 {
     public List<MeshGroup> Groups { get; set; } = [];
 
+    protected override void Reset()
+    {
+        Groups.Clear();
+    }
+
     public override void ResolveDependencies(IResourceResolver resolver)
     {
         List<ResourceResolveException> exceptions = [];

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/TerrainModel.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ModelData/TerrainModel.cs
@@ -40,4 +40,10 @@ public class TerrainModel : ModelBase
             writer.Write(Flags);
         }
     }
+
+    protected override void Reset()
+    {
+        base.Reset();
+        Flags = default;
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/PackedFileInfo.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/PackedFileInfo.cs
@@ -30,6 +30,11 @@ public class PackedFileInfo : SampleChunkResource
         });
     }
 
+    protected override void Reset()
+    {
+        Files.Clear();
+    }
+
     public struct File : IBinarySerializable
     {
         public string? Name { get; set; }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ShaderData/BaseShader.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ShaderData/BaseShader.cs
@@ -6,7 +6,7 @@ public abstract class BaseShader : SampleChunkResource
 
     public ResourceReference<ResourceRaw> ByteCode { get; set; }
 
-    public ShaderByteCodePlatform ByteCodePlatform = ShaderByteCodePlatform.None;
+    public ShaderByteCodePlatform ByteCodePlatform { get; set; } = ShaderByteCodePlatform.None;
 
     public List<ResourceReference<ShaderParameter>> Parameters { get; set; } = [];
 
@@ -44,6 +44,13 @@ public abstract class BaseShader : SampleChunkResource
                 writer.WriteStringOffset(StringBinaryFormat.NullTerminated, Path.GetFileNameWithoutExtension(parameter.Name));
             }
         });
+    }
+
+    protected override void Reset()
+    {
+        ByteCode = default;
+        ByteCodePlatform = ShaderByteCodePlatform.None;
+        Parameters.Clear();
     }
 
     public override void ResolveDependencies(IResourceResolver resolver)

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ShaderData/ShaderList.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ShaderData/ShaderList.cs
@@ -83,6 +83,14 @@ public class ShaderList : SampleChunkResource
         }, 4);
     }
 
+    protected override void Reset()
+    {
+        PixelShaderPermutations.Clear();
+        HasInputs = default;
+        ParameterInputs.Clear();
+        TextureInputs.Clear();
+    }
+
     public override void ResolveDependencies(IResourceResolver dir)
     {
         foreach (PixelShaderPermutation permutation in PixelShaderPermutations)

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ShaderData/ShaderParameter.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/ShaderData/ShaderParameter.cs
@@ -72,4 +72,12 @@ public class ShaderParameter : SampleChunkResource
             });
         }
     }
+
+    protected override void Reset()
+    {
+        for (int i = 0; i < UsageSet.Length; i++)
+        {
+            UsageSet[i] = [];
+        }
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/Terrain.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/Terrain.cs
@@ -20,4 +20,9 @@ public class Terrain : SampleChunkResource
             }
         });
     }
+
+    protected override void Reset()
+    {
+        Groups.Clear();
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/TerrainBlockSphereTree.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/TerrainBlockSphereTree.cs
@@ -121,6 +121,11 @@ public class TerrainBlockSphereTree : SampleChunkResource
         }
     }
 
+    protected override void Reset()
+    {
+        Root = new(default);
+    }
+
     [StructLayout(LayoutKind.Explicit)]
     private struct BinaryNode : IBinarySerializable
     {

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/TerrainGroup.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/TerrainGroup.cs
@@ -54,4 +54,9 @@ public class TerrainGroup : SampleChunkResource
         });
     }
 
+    protected override void Reset()
+    {
+        ModelNames.Clear();
+        Subsets.Clear();
+    }
 }

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/TerrainInstanceInfo.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/TerrainData/TerrainInstanceInfo.cs
@@ -61,6 +61,13 @@ public class TerrainInstanceInfo : SampleChunkResource
         }
     }
 
+    protected override void Reset()
+    {
+        Model = default;
+        Transform = default;
+        LightGroups.Clear();
+    }
+
     public override void ResolveDependencies(IResourceResolver resolver)
     {
         if (Model.IsValid())


### PR DESCRIPTION
Added fallback reader for Sample Chunk V2 resources with broken data sizes (hedge edit materials).
