### PR TITLE
Fixed `SampleChunkNode` bugs

### DIFF
--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/SampleChunkNode.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/SampleChunkNode.cs
@@ -322,7 +322,7 @@ public class SampleChunkNode : IBinarySerializable, IEnumerable<SampleChunkNode>
         }
 
         long end = startPos + size;
-        if (end > reader.Position)
+        if (end >= reader.Position)
         {
             DataOffset = reader.Position;
             DataSize = end - DataOffset;

--- a/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/SampleChunkResource.cs
+++ b/Source/SharpNeedle/Framework/HedgehogEngine/Mirage/SampleChunkResource.cs
@@ -21,9 +21,12 @@ public abstract class SampleChunkResource : ResourceBase, IBinarySerializable
 
     public void SetupNodes(string rootName)
     {
-        Root = new();
+        Root = new()
+        {
+            Value = SampleChunkNode.RootSignature
+        };
 
-        SampleChunkNode dataRoot = new(rootName);
+        SampleChunkNode dataRoot = new(rootName, 1);
         Root.AddChild(dataRoot);
 
         dataRoot.AddChild(new("Contexts", this, DataVersion));


### PR DESCRIPTION
Fixed bugs:
- `SampleChunkNode`s with no extra data had a dataoffset of 0, invalidating the reader for some nodes
- `SampleChunkResource.SetupNodes(..)` did not set up the root with the root signature (not needed for writing, but needed for when wanting to use other parsers)
- `SampleChunkResource.SetupNodes(..)` now setting up the roots child with the value 1 (this is how the games do it)